### PR TITLE
Check `created` field, otherwise assign to `time.Now`

### DIFF
--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -63,12 +63,17 @@ func (iter *Snapshot) Next() (sdk.Record, error) {
 
 	iter.position.Cursor = iter.response.Data[iter.index][idKey].(string)
 
+	created, ok := iter.response.Data[iter.index]["created"].(float64)
+	if !ok {
+		created = float64(time.Now().Unix())
+	}
+
 	output := sdk.Record{
 		Position: iter.position.FormatSDKPosition(),
 		Metadata: map[string]string{
 			models.ActionKey: models.InsertAction,
 		},
-		CreatedAt: time.Unix(int64(iter.response.Data[iter.index]["created"].(float64)), 0),
+		CreatedAt: time.Unix(int64(created), 0),
 		Key: sdk.StructuredData{
 			idKey: iter.response.Data[iter.index][idKey].(string),
 		},


### PR DESCRIPTION
### Description

Fix a bug with resources that don't have `created` field.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-stripe/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
