### PR TITLE
fix the case when there is no error in case if batchSize is zero

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,5 @@ jobs:
 
       - name: Test
         env:
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          STRIPE_RESOUSE_NAME: ${{ secrets.STRIPE_RESOUSE_NAME }}
+          secretKey: ${{ secrets.STRIPE_SECRET_KEY }}
         run: make test GOTEST_FLAGS="-v -count=1"

--- a/clients/http/http.go
+++ b/clients/http/http.go
@@ -32,10 +32,8 @@ type Client struct {
 
 // NewClient returns a new retryable http client.
 func NewClient() Client {
-	retryClient := retryablehttp.NewClient()
-
 	return Client{
-		httpClient: retryClient,
+		httpClient: retryablehttp.NewClient(),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ const (
 type Config struct {
 	SecretKey    string `validate:"required"`
 	ResourceName string `validate:"required,resource_name"`
-	BatchSize    int    `validate:"omitempty,gte=1,lte=100"`
+	BatchSize    int
 }
 
 // Parse parses Stripe configuration into a Config struct.
@@ -49,6 +49,10 @@ func Parse(cfg map[string]string) (Config, error) {
 		batchSize, err := strconv.Atoi(cfg[BatchSize])
 		if err != nil {
 			return Config{}, validator.IntegerTypeConfigErr(BatchSize)
+		}
+
+		if batchSize <= 0 || batchSize > 100 {
+			return Config{}, validator.InvalidBatchSizeErr(BatchSize)
 		}
 
 		config.BatchSize = batchSize

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,24 +97,34 @@ func TestParse(t *testing.T) {
 			expectedErr: validator.IntegerTypeConfigErr(BatchSize).Error(),
 		},
 		{
-			name: "batch size is out of range (more than the maximum)",
+			name: "batch size is greater than or equal to 100",
 			in: map[string]string{
 				SecretKey:    "sk_51JB",
 				ResourceName: "subscription",
 				BatchSize:    "110",
 			},
 			wantErr:     true,
-			expectedErr: validator.OutOfRangeConfigErr(BatchSize).Error(),
+			expectedErr: validator.InvalidBatchSizeErr(BatchSize).Error(),
 		},
 		{
-			name: "batch size is out of range (less than the minimum)",
+			name: "batch size less than or equal to 1",
+			in: map[string]string{
+				SecretKey:    "sk_51JB",
+				ResourceName: "subscription",
+				BatchSize:    "0",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidBatchSizeErr(BatchSize).Error(),
+		},
+		{
+			name: "batch size is negative",
 			in: map[string]string{
 				SecretKey:    "sk_51JB",
 				ResourceName: "subscription",
 				BatchSize:    "-1",
 			},
 			wantErr:     true,
-			expectedErr: validator.OutOfRangeConfigErr(BatchSize).Error(),
+			expectedErr: validator.InvalidBatchSizeErr(BatchSize).Error(),
 		},
 	}
 

--- a/config/validator.go
+++ b/config/validator.go
@@ -38,8 +38,6 @@ func (c Config) Validate() error {
 				err = multierr.Append(err, validator.RequiredErr(c.configName(e.Field())))
 			case "resource_name":
 				err = multierr.Append(err, validator.WrongResourceNameErr(c.configName(e.Field())))
-			case "gte", "lte":
-				err = multierr.Append(err, validator.OutOfRangeConfigErr(c.configName(e.Field())))
 			}
 		}
 	}

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -36,7 +36,7 @@ func IntegerTypeConfigErr(name string) error {
 	return fmt.Errorf("%q config value must be an integer", name)
 }
 
-// OutOfRangeConfigErr returns the formatted out of range error.
-func OutOfRangeConfigErr(name string) error {
-	return fmt.Errorf("%q is out of range", name)
+// InvalidBatchSizeErr returns the formatted invalid batch size value error.
+func InvalidBatchSizeErr(name string) error {
+	return fmt.Errorf("%q must be greater than or equal to 1 and less than or equal to 100", name)
 }


### PR DESCRIPTION
### Description

Please include a summary of the change and what type of change it is (new feature, bug fix, refactoring, documentation).
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-stripe/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
